### PR TITLE
  Теперь функция sendEmailWithJson() работает идентично вашему тестовому

### DIFF
--- a/js/api/server.js
+++ b/js/api/server.js
@@ -671,16 +671,9 @@ function createMissingModelsJson(missingModels, stats, userId, projectInfo, user
  * Отправляет email с JSON отчетом (используя рабочую конфигурацию из test-email-sending.js)
  */
 async function sendEmailWithJson(jsonData, userId, stats, userEmail) {
-    const isDevelopment = process.env.NODE_ENV === 'development' || 
-                         process.env.NODE_ENV !== 'production';
-    
-    if (isDevelopment) {
-        return { messageId: 'dev-mode-' + Date.now(), development: true };
-    }
-
     try {
         console.log('1. Создание транспорта...');
-        const transporter = nodemailer.createTransporter({
+        const transporter = nodemailer.createTransport({
             host: 'smtp.mail.ru',
             port: 465,
             secure: true, // true для порта 465, false для других портов


### PR DESCRIPTION
скрипту. Email будет отправляться при вызове API endpoint
/api/send-missing-models-report.

## Краткое описание от Sourcery

Использовать production-транспорт электронной почты в sendEmailWithJson, удалив обходной путь для режима разработки и исправив создание экземпляра транспортера.

Улучшения:
- Всегда отправлять реальные электронные письма в sendEmailWithJson, удалив заглушку dev-mode
- Заменить `nodemailer.createTransporter` на `nodemailer.createTransport` для доставки электронной почты

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use production email transport in sendEmailWithJson by removing the development-mode bypass and correcting the transporter instantiation

Enhancements:
- Always send real emails in sendEmailWithJson by removing the dev-mode stub
- Replace nodemailer.createTransporter with nodemailer.createTransport for email delivery

</details>